### PR TITLE
New error behaviour, fixes #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lib
 .gobble
 .gobble-build
 .gobble-watch
+.idea

--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ module.exports = {
 
 	Socket: require(dir + "/artemisSocket"),
 // 	artemisServer: require(dir + "/artemisServer"),
-	Constants: require(dir + "/enum-constants")
+	Constants: require(dir + "/enum-constants"),
+
+	// To allow instanceof ParseError checks
+	ParseError: require(dir + "/parseError")
 
 };
 

--- a/src/artemisSocket.js
+++ b/src/artemisSocket.js
@@ -18,13 +18,6 @@ class Socket extends net.Socket {
 		this._debug = !!options.debug;
 		this._buffer = null;
 		this.on('data', this._parseData);
-
-		this.on('error', this._onError);
-	}
-
-	_onError() {
-		// Close the connection for 'critical' errors
-		this.close();
 	}
 
 

--- a/src/artemisSocket.js
+++ b/src/artemisSocket.js
@@ -100,7 +100,7 @@ class Socket extends net.Socket {
 			try {
 				packet       = packetDefsByType[header.type][subtype].fields.unpack(buffer);
 			} catch(err) {
-				this.emit('error', new ParseError('Could not parse packet (' + header.type.toString(16) + ',' + subtype.toString(16) + '): ' + err.message, buffer));
+				this.emit('unparsed', new ParseError('Could not parse packet (' + header.type.toString(16) + ',' + subtype.toString(16) + '): ' + err.message, buffer));
 				return this._parseData( remainingBuffer );
 			}
 

--- a/src/artemisSocket.js
+++ b/src/artemisSocket.js
@@ -67,7 +67,7 @@ class Socket extends net.Socket {
 		this._buffer = null;
 
 		if (!packetDefsByType.hasOwnProperty( header.type )) {
-			this.emit('warn', new ParseError('Unknown packet type: ', header.type.toString(16), ' skipping.', buffer));
+			this.emit('unparsed', new ParseError('Unknown packet type: ', header.type.toString(16), ' skipping.', buffer));
 			return this._parseData( remainingBuffer );
 		}
 
@@ -90,7 +90,7 @@ class Socket extends net.Socket {
 			}
 
 			if (!packetDefsByType[ header.type ].hasOwnProperty( subtype )) {
-				this.emit('warn', new ParseError('Unknown packet subtype: ', header.type.toString(16),subtype.toString(16), ' skipping.', buffer));
+				this.emit('unparsed', new ParseError('Unknown packet subtype: ', header.type.toString(16),subtype.toString(16), ' skipping.', buffer));
 				buffer.pointer = initialPointer;
 				return this._parseData( remainingBuffer );
 			}
@@ -111,7 +111,7 @@ class Socket extends net.Socket {
 
 		if (buffer.pointer !== initialPointer + header.packetLength) {
 			var bytesRead = buffer.pointer - initialPointer;
-			this.emit('warn', new ParseError('Packet length mismatch ( expected ' + header.packetLength + ' read ' + bytesRead + ')', buffer));
+			this.emit('unparsed', new ParseError('Packet length mismatch ( expected ' + header.packetLength + ' read ' + bytesRead + ')', buffer));
 		}
 
 		return this._parseData( remainingBuffer );

--- a/src/parseError.js
+++ b/src/parseError.js
@@ -1,0 +1,51 @@
+'use strict';
+
+// Called when a ParseError is ToStringed
+function debugBuffer(buffer) {
+	var str = '';
+	for (var i = 0; i < buffer.length; i++) {
+		var hex = buffer.readUInt8(i).toString(16);
+		if (hex.length < 2) {
+			hex = "0" + hex;
+		}
+		str += hex + ' ';
+	}
+	return str;
+}
+
+class ParseError extends Error {
+
+	constructor(message, buffer) {
+		super();
+		Error.captureStackTrace(this, this.constructor);
+
+		// Makes sure the values act like proper Error values
+		Object.defineProperties(this, {
+			message: {value: message},
+			buffer:  {value: buffer}
+		});
+	}
+
+	get name() {
+		return this.constructor.name;
+	}
+
+	toString() {
+		return this.message +
+			'\nBuffer data is:\n' +
+			debugBuffer(this.buffer) + '\n' +
+			this.stack;
+	}
+
+	debugBuffer() {
+		var str = '';
+		for (var i = 0; i < this.buffer.length; i++) {
+			var hex = this.buffer.readUInt8(i).toString(16);
+			// todo
+		}
+	}
+
+}
+
+
+module.exports = ParseError;


### PR DESCRIPTION
Fixes https://github.com/IvanSanchez/node-artemis-lib/issues/5.
Implements two events for error behaviour: one for 'critical' errors such as bad magic number or bad header, the other for not-so-critical errors such as unknown type/subtype, length mismatch, etc.
