### PR TITLE
Added Generic Mesh subtype

### DIFF
--- a/src/data-types.js
+++ b/src/data-types.js
@@ -87,6 +87,18 @@ export function getTypes(options) {
 		}
 	}
 
+	var int64 = {
+		unpack: function(buffer){
+			var value = buffer.readUInt64LE(buffer.pointer);
+			buffer.pointer += 8;
+			return value;
+		},
+		pack: function(buffer, value){
+			buffer.writeUInt64LE(value || 0, buffer.pointer);
+			buffer.pointer += 8;
+		}
+	}
+
 	var bool8, bool16, bool32;
 	if (options.bool) {
 		bool8 = {

--- a/src/packet-defs.js
+++ b/src/packet-defs.js
@@ -739,13 +739,13 @@ export function getPacketDefs(options) {
 					unknown08:   type.int32,
 				
 					unknown09:   type.int32,
-					unknown10:   type.int32,
+					unknown10:   type.int64, //Long
 					shipName:    type.string,
 					meshFile:    type.string,
 					textureFile: type.string,
 					unknown14:   type.int32,
 					unknown15:   type.int16,
-					unknown16:   type.bool8,
+					unknown16:   type.int8,
 				
 					colorR:      type.float,
 					colorG:      type.float,

--- a/src/packet-defs.js
+++ b/src/packet-defs.js
@@ -721,12 +721,47 @@ export function getPacketDefs(options) {
 				})                       
 			})
 		},
-		
-		
-		//// FIXME: Add subtype 0x0e, presumably generic mesh.
-		//// Sample packet type+subtype+payload:
-		//// fe c8 54 f7 0e 00 00 00 00 00 00 00 94 bb 10 3e
 
+		genericMesh: {
+		  	type: 0x80803df9,
+		  	subtypeLength: 1,
+		  	subtype: 0x0e,	// 14
+		  	fields: type.struct({
+			    	id: type.int32,
+			    	data: type.bitmapstruct(1,{
+					posX:        type.float,
+					posY:        type.float,
+					posZ:        type.float,
+					unknown04:   type.int32,
+					unknown05:   type.int32,
+					unknown06:   type.int64, //Long
+					unknown07:   type.int32,
+					unknown08:   type.int32,
+				
+					unknown09:   type.int32,
+					unknown10:   type.int32,
+					shipName:    type.string,
+					meshFile:    type.string,
+					textureFile: type.string,
+					unknown14:   type.int32,
+					unknown15:   type.int16,
+					unknown16:   type.bool8,
+				
+					colorR:      type.float,
+					colorG:      type.float,
+					colorB:      type.float,
+					forShields:  type.float,
+					aftShields:  type.float,
+					unknown22:   type.int32,
+					unknown23:   type.int32,
+					unknown24:   type.int32,
+					
+					unknown25:   type.int32,
+					unknown26:   type.int32,
+		    		})
+			})
+		},
+		
 		monster: {
 			type: 0x80803df9,
 			subtypeLength: 1,


### PR DESCRIPTION
I added the genericMesh (type -> 0x0e) based on the protocol docs. It also required a long int, so I created the int64 type as well. Hopefully I added them correctly - I have never programmed for Node.js before now.
